### PR TITLE
Add slide list from Speakerdeck

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "remark-external-links": "^10.0.0",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "fast-xml-parser": "^4.5.1"
   },
   "volta": {
     "node": "20.10.0"

--- a/src/libs/fetchSpeakerdeckSlides.ts
+++ b/src/libs/fetchSpeakerdeckSlides.ts
@@ -1,0 +1,24 @@
+import fetch from 'node-fetch';
+import { XMLParser } from 'fast-xml-parser';
+import { Article } from '../models/Article';
+
+export async function fetchSpeakerdeckSlides(): Promise<readonly Article[]> {
+  const res = await fetch('https://speakerdeck.com/yukukotani.rss');
+  const xml = await res.text();
+
+  const parser = new XMLParser({ ignoreAttributes: false });
+  const parsed = parser.parse(xml);
+
+  // According to RSS structure: parsed.rss.channel.item is array
+  const items = parsed?.rss?.channel?.item ?? [];
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  return items.map((item: any) => ({
+    source: 'speakerdeck',
+    publishDate: new Date(item.pubDate),
+    title: item.title,
+    url: item.link,
+  }));
+}

--- a/src/models/Article.ts
+++ b/src/models/Article.ts
@@ -1,4 +1,4 @@
-type ArticleSource = 'internal' | 'zenn' | 'note';
+type ArticleSource = 'internal' | 'zenn' | 'note' | 'speakerdeck';
 
 export type Article = {
   source: ArticleSource;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import { Container } from '../components/Container';
 import { fetchYukuZennArticles, fetchUbieZennArticles } from '../libs/fetchZennArticles';
 import { Footer } from '../components/Footer';
 import { fetchNoteArticles } from '../libs/fetchNoteArticles';
+import { fetchSpeakerdeckSlides } from '../libs/fetchSpeakerdeckSlides';
 
 const rawInternalArticles = await Astro.glob('./articles/**/*.md');
 const internalArticles: Article[] = rawInternalArticles.map((article) => ({
@@ -19,6 +20,7 @@ const internalArticles: Article[] = rawInternalArticles.map((article) => ({
 const yukuZennArticles = await fetchYukuZennArticles();
 const ubieZennArticles = await fetchUbieZennArticles();
 const noteArticles = await fetchNoteArticles();
+const speakerdeckSlides = await fetchSpeakerdeckSlides();
 ---
 
 <html lang="ja">
@@ -28,9 +30,11 @@ const noteArticles = await fetchNoteArticles();
 
   <body>
     <BlogHeader />
-    <Container>
-      <ArticleList articles={[...internalArticles, ...yukuZennArticles, ...ubieZennArticles, ...noteArticles]} />
-    </Container>
+      <Container>
+        <ArticleList articles={[...internalArticles, ...yukuZennArticles, ...ubieZennArticles, ...noteArticles]} />
+        <h2>Slides</h2>
+        <ArticleList articles={speakerdeckSlides} />
+      </Container>
     <Footer />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch slide data from Speakerdeck RSS
- allow new article source `speakerdeck`
- show slide list on top page below the article list
- install `fast-xml-parser` dependency

## Testing
- `pnpm run build` *(fails: getaddrinfo ENOTFOUND zenn.dev)*