### PR TITLE
fix: Update Astro to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@astrojs/rss": "^4.0.10",
     "@types/node-fetch": "^2.6.12",
     "@ubie/prettier-config": "^0.1.0",
-    "astro": "^5.1.1",
+    "astro": "^5.2.0",
     "prettier": "^3.4.2",
     "prettier-plugin-astro": "^0.14.1",
     "sass": "^1.83.0"


### PR DESCRIPTION
Closes #10

Patch generated by `qwen3.6-35b-a3b via local API`.